### PR TITLE
No duplicate effort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ env:
 install:
   - source ci/travis/install.sh
 script:
-  - python ci/main.py recipes
+  - python ci/main.py recipes biocore

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ How to create a recipe is documented on [conda's website](http://conda-test.pyda
 
 You can also borrow from the examples located in this repository: [recipes](https://github.com/biocore/conda-recipes/tree/master/recipes). There are also lots of examples in conda's conda-recipes [repository](https://github.com/conda/conda-recipes/).
 
+## Modify an existing conda recipe
+If you modified an existing recipe in this repository and would like to merge it back, you should increment the build number by one. This will trigger the rebuilding of the package upon your updated recipe.
+
+For example, if the current recipe has this in the `meta.yaml`:
+
+	build:
+	  number: 1
+
+you should change it to the following after you modify it:
+
+	build:
+	  number: 2
+
+If there is no such section in `meta.yaml`, the build number defaults to zero. You should set it to 1 after modifying it. Please see the documentation [here](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
 
 ## Build a conda package
 You need to install the following mandatory toolset before building a package.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ How to create a recipe is documented on [conda's website](http://conda-test.pyda
 You can also borrow from the examples located in this repository: [recipes](https://github.com/biocore/conda-recipes/tree/master/recipes). There are also lots of examples in conda's conda-recipes [repository](https://github.com/conda/conda-recipes/).
 
 ## Modify an existing conda recipe
-If you modified an existing recipe in this repository and would like to merge it back, you should increment the build number by one. This will trigger the rebuilding of the package upon your updated recipe.
+If you modified an existing recipe in this repository and would like to merge it back, you should increment the build number by one in order to trigger a package rebuild. This is not necessary if the package version is changing, and you will need to add the build number section to the `meta.yaml` file if it doesn't already exist.
 
 For example, if the current recipe has this in the `meta.yaml`:
 

--- a/ci/main.py
+++ b/ci/main.py
@@ -118,4 +118,4 @@ def upload(name, version, channel):
 
 
 if __name__ == '__main__':
-    build_upload_recipes(sys.argv[1], 'zechxu')
+    build_upload_recipes(sys.argv[1], sys.argv[2])

--- a/ci/main.py
+++ b/ci/main.py
@@ -40,7 +40,7 @@ def build_upload_recipes(p, channel):
                 except KeyError:
                     # Build number is 0 if not specified
                     build_number = 0
-                if is_already_uploaded(name, version, build_number):
+                if is_already_uploaded(name, version, build_number, channel):
                     # Only new packages (either version or build_number)
                     log.info("Skipping package: {0}-{1}".format(name, version))
                     continue
@@ -48,14 +48,20 @@ def build_upload_recipes(p, channel):
                 if os.environ['TRAVIS_SECURE_ENV_VARS'] == 'true':
                     upload(name, version, channel)
                 else:
-                    print("Uploading not available in Pull Requests")
+                    log.info("Uploading not available in Pull Requests")
 
 
 def build(name, version, root):
-    log.info("Building package: {0}-{1}".format(name, version))
+    '''Build a recipe.
+
+    Parameters
+    ----------
+    root : str
+        the directory path for the recipe.
+    '''
     # Quote is need in case the root path has spaces in it.
     build_cmd = 'conda build "%s"' % root
-    print('BUILDING COMMAND: {0}'.format(build_cmd))
+    log.info('Build: {0}'.format(build_cmd))
     check_call(build_cmd, shell=True)
 
 
@@ -79,20 +85,20 @@ def is_already_uploaded(name, version, build_number, channel):
     Returns
     -------
     Bool
-        If a previous package in the channel has the same name, the same
-        version, and an equal or higher build number, then return False;
-        otherwise, return True.
-    '''
+        If a package in the channel has the same name, the same
+        version, and an equal or higher build number, then return
+        True; otherwise, return False.
 
+    '''
     check_cmd = ('conda search --json --override-channels '
                  '-c {0} --spec {1}={2}').format(
-                     CHANNEL, name, version)
-    print('CHECKING COMMAND: {0}'.format(check_cmd))
+                     channel, name, version)
+    log.info('Check: {0}'.format(check_cmd))
     out = check_output(check_cmd, shell=True)
     res = json.loads(out)
     return all((name in res,
                 res[name][0]['version'] == version,
-                res[name][0]['build_number'] == build_number))
+                res[name][0]['build_number'] >= build_number))
 
 
 def upload(name, version, channel):
@@ -107,17 +113,16 @@ def upload(name, version, channel):
     channel : str
         Channel where the package will be uploaded.
     '''
-
     built_glob = os.path.join(
         config.bldpkgs_dir,
         '{0}-{1}*.tar.bz2'.format(name, version))
     built = glob.glob(built_glob)[0]
     upload_cmd = 'anaconda -t {token} upload -u {channel} {built}'
     # Do not show decrypted token!
-    log.info('Upload: {0}'.format(cmd))
+    log.info('Upload: {0}'.format(upload_cmd))
     check_call(
         upload_cmd.format(
-            token=os.environ['ANACONDA_TOKEN'], 
+            token=os.environ['ANACONDA_TOKEN'],
             built=built,
             channel=channel),
         shell=True)

--- a/ci/main.py
+++ b/ci/main.py
@@ -3,61 +3,119 @@ import sys
 import json
 import yaml
 import glob
-from subprocess import check_call, check_output, CalledProcessError
+from subprocess import check_call, check_output
 
 from conda_build.config import config
 
 
-CHANNEL = 'https://conda.anaconda.org/biocore'
+def build_upload_recipes(p, channel):
+    '''Build & upload recipes recursively in a directory.
 
-
-def build_upload_recipes(p):
+    Parameters
+    ----------
+    p : str
+        directory path to the recipes
+    channel : str
+        the channel where the packages will be uploaded.
+    '''
     for root, dirs, files in os.walk(p):
         has_recipe = 'meta.yaml' in files
         if not dirs and has_recipe:
             with open(os.path.join(root, 'meta.yaml')) as f:
-                pkg = yaml.load(f)['package']
+                meta = yaml.load(f)
+                build_n = meta['build']['number']
+                pkg = meta['package']
                 name = pkg['name']
                 version = pkg['version']
-                build(name, version, root)
-                if os.environ['TRAVIS_SECURE_ENV_VARS'] == 'true':
-                    upload(name, version)
-                else:
-                    print("Uploading not available in Pull Requests")
+                if check(name, version, build_n, channel):
+                    build(name, version, root)
+                    if os.environ['TRAVIS_SECURE_ENV_VARS'] == 'true':
+                        upload(name, version, channel)
+                    else:
+                        print("Uploading not available in Pull Requests")
+
+
+def check(name, version, build_n, channel):
+    '''Check if we want to build & upload a package.
+
+    It checks package name, package version, and package build number
+    sequentially to decide whether to return True or not.
+
+    Parameters
+    ----------
+    name : str
+        package name.
+    version : str
+        package version.
+    build_n : int
+        build number
+    channel : str
+        the channel to check the previous built.
+
+    Returns
+    -------
+    boolean
+        If a previous package in the channel has the same name, the same
+        version, and an equal or higher build number, then return False;
+        otherwise, return True.
+    '''
+    cmd = ('conda search --json --override-channels '
+           '-c {0} --spec {1}').format(channel, name)
+    print('CHECKING COMMAND: {0}'.format(cmd))
+    out = check_output(cmd, shell=True)
+    res = json.loads(out)
+    if name not in res:
+        return True
+    if version != res[name][1]['version']:
+        return True
+    if build_n > res[name][0]['build_n']:
+        return True
+    return False
 
 
 def build(name, version, root):
+    '''Build a recipe.
+
+    Parameters
+    ----------
+    name : str
+        package name.
+    version : str
+        package version.
+    root : str
+        the directory path for the recipe.
+    '''
     print("Building package: {0}-{1}".format(name, version))
     # Quote is need in case the root path has spaces in it.
-    build_cmd = 'conda build "%s"' % root
-    print('BUILDING COMMAND: {0}'.format(build_cmd))
-    check_call(build_cmd, shell=True)
+    cmd = 'conda build "{0}"'.format(root)
+    print('BUILDING COMMAND: {0}'.format(cmd))
+    check_call(cmd, shell=True)
 
 
-def upload(name, version):
-    check_cmd = ('conda search --json --override-channels '
-                 '-c {0} --spec {1}={2}').format(
-                     CHANNEL, name, version)
-    print('CHECKING COMMAND: {0}'.format(check_cmd))
-    try:
-        out = check_output(check_cmd, shell=True)
-    except CalledProcessError as e:
-        # This built version does not exist in the channel
-        out = e.output
-    res = json.loads(out)
-    if name not in res:
-        built_glob = os.path.join(
-            config.bldpkgs_dir,
-            '{0}-{1}*.tar.bz2'.format(name, version))
-        built = glob.glob(built_glob)[0]
-        upload_cmd = 'anaconda -t {token} upload -u biocore {built}'
-        # Do not show decrypted token!
-        print('UPLOADING COMMAND: {0}'.format(upload_cmd))
-        check_call(
-            upload_cmd.format(
-                token=os.environ['ANACONDA_TOKEN'], built=built),
-            shell=True)
+def upload(name, version, channel):
+    '''Upload a built package.
+
+    Parameters
+    ----------
+    name : str
+        package name.
+    version : str
+        package version.
+    channel : str
+        the channel where the package will be uploaded.
+    '''
+    built_glob = os.path.join(
+        config.bldpkgs_dir, '{0}-{1}*.tar.bz2'.format(name, version))
+    built = glob.glob(built_glob)[0]
+    cmd = 'anaconda -t {token} upload -u {channel} {built}'
+    # Do not show decrypted token!
+    print('UPLOADING COMMAND: {0}'.format(cmd))
+    check_call(
+        cmd.format(token=os.environ['ANACONDA_TOKEN'],
+                   channel=channel,
+                   built=built),
+        shell=True)
 
 
 if __name__ == '__main__':
-    build_upload_recipes(sys.argv[1])
+    build_upload_recipes(sys.argv[1], 'zechxu')

--- a/ci/main.py
+++ b/ci/main.py
@@ -44,14 +44,14 @@ def build_upload_recipes(p, channel):
                     # Only new packages (either version or build_number)
                     log.info("Skipping package: {0}-{1}".format(name, version))
                     continue
-                build(name, version, root)
+                build(root)
                 if os.environ['TRAVIS_SECURE_ENV_VARS'] == 'true':
                     upload(name, version, channel)
                 else:
                     log.info("Uploading not available in Pull Requests")
 
 
-def build(name, version, root):
+def build(root):
     '''Build a recipe.
 
     Parameters
@@ -61,7 +61,7 @@ def build(name, version, root):
     '''
     # Quote is need in case the root path has spaces in it.
     build_cmd = 'conda build "%s"' % root
-    log.info('Build: {0}'.format(build_cmd))
+    log.info('Building: {0}'.format(build_cmd))
     check_call(build_cmd, shell=True)
 
 
@@ -93,7 +93,7 @@ def is_already_uploaded(name, version, build_number, channel):
     check_cmd = ('conda search --json --override-channels '
                  '-c {0} --spec {1}={2}').format(
                      channel, name, version)
-    log.info('Check: {0}'.format(check_cmd))
+    log.info('Checking: {0}'.format(check_cmd))
     out = check_output(check_cmd, shell=True)
     res = json.loads(out)
     return all((name in res,
@@ -119,7 +119,7 @@ def upload(name, version, channel):
     built = glob.glob(built_glob)[0]
     upload_cmd = 'anaconda -t {token} upload -u {channel} {built}'
     # Do not show decrypted token!
-    log.info('Upload: {0}'.format(upload_cmd))
+    log.info('Uploading: {0}'.format(upload_cmd))
     check_call(
         upload_cmd.format(
             token=os.environ['ANACONDA_TOKEN'],

--- a/ci/main.py
+++ b/ci/main.py
@@ -16,11 +16,14 @@ def build_upload_recipes(p):
         has_recipe = 'meta.yaml' in files
         if not dirs and has_recipe:
             with open(os.path.join(root, 'meta.yaml')) as f:
-                pkg = yaml.load(f)['package']
-                name = pkg['name']
-                version = pkg['version']
-                # If no build number stated in the recipe, consider it 0
-                build_number = pkg.get('build_number', 0)
+                meta = yaml.load(f)
+                name = meta['package']['name']
+                version = meta['package']['version']
+                try:
+                    build_number = meta['build']['number']
+                except KeyError:
+                    # Build number is 0 if not specified
+                    build_number = 0
                 if is_already_uploaded(name, version, build_number):
                     # Only new packages (either version or build_number)
                     print("Skipping package: {0}-{1}".format(name, version))

--- a/ci/main.py
+++ b/ci/main.py
@@ -32,6 +32,7 @@ def build_upload_recipes(p, channel):
         has_recipe = 'meta.yaml' in files
         if not dirs and has_recipe:
             with open(os.path.join(root, 'meta.yaml')) as f:
+                log.info("Checking {}".format(root))
                 meta = yaml.load(f)
                 name = meta['package']['name']
                 version = meta['package']['version']
@@ -91,8 +92,8 @@ def is_already_uploaded(name, version, build_number, channel):
 
     '''
     check_cmd = ('conda search --json --override-channels '
-                 '-c {0} --spec {1}={2}').format(
-                     channel, name, version)
+                 '-c {0} --spec {1}').format(
+                     channel, name)
     log.info('Checking: {0}'.format(check_cmd))
     out = check_output(check_cmd, shell=True)
     res = json.loads(out)

--- a/ci/main.py
+++ b/ci/main.py
@@ -47,9 +47,9 @@ def is_already_uploaded(name, version, build_number):
     print('CHECKING COMMAND: {0}'.format(check_cmd))
     out = check_output(check_cmd, shell=True)
     res = json.loads(out)
-    return all(name in res,
-               res[name][0]['version'] == version,
-               res[name][0]['build_number'] == build_number)
+    return all((name in res,
+                res[name][0]['version'] == version,
+                res[name][0]['build_number'] == build_number))
 
 
 def upload(name, version):

--- a/ci/main.py
+++ b/ci/main.py
@@ -22,6 +22,7 @@ def build_upload_recipes(p):
                 build_number = pkg['build_number']
                 if is_already_uploaded(name, version, build_number):
                     # Only new packages (either version or build_number)
+                    print("Skipping package: {0}-{1}".format(name, version))
                     continue
                 build(name, version, root)
                 if os.environ['TRAVIS_SECURE_ENV_VARS'] == 'true':

--- a/ci/main.py
+++ b/ci/main.py
@@ -19,7 +19,8 @@ def build_upload_recipes(p):
                 pkg = yaml.load(f)['package']
                 name = pkg['name']
                 version = pkg['version']
-                build_number = pkg['build_number']
+                # If no build number stated in the recipe, consider it 0
+                build_number = pkg.get('build_number', 0)
                 if is_already_uploaded(name, version, build_number):
                     # Only new packages (either version or build_number)
                     print("Skipping package: {0}-{1}".format(name, version))


### PR DESCRIPTION
Fixes #6.

Check if packages are already available in Anaconda, and if they have same version, build number and name, avoid building/uploading them.

Should save a lot of travis time.
