### PR TITLE
UPD: Update to py3 by default, and build in py3.5 and np1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     # CONDA_PY and CONDA_NPY are the env variable of python version
     # and numpy version used by "conda build"
     # to build the packages.
-    - CONDA_PY=34  CONDA_NPY=18
+    - CONDA_PY=35  CONDA_NPY=110
   global:
     secure: gKgj4jR2N8WbVBnJCI52zMR21/nd2hWUb05DatiWNJ8pZ+CC6CPD7N/2t8k+y5V25NufI5ZpEBEnGbmV1AxS6ISjPHRejoQgDYTw/PjY4NEIssFVbULIB84FD9SY7/oqkr5L+jrEyDeV52d2LfSAHjwWlL4XYZ7OFdH7HW/5yUj1z4jasfFhv41x8tVknXWAeS1AEdAfwnb4lEeKvlP6jxdfqkQv9PeobM+THV7gGtUo9rA+plZuhQDzXhywRKajEbYbA7/eHzQa5kMYtf8EQl/orDOPCSMEjh9ifCsf0bcFuQkqtOKhgPGVihNdw9PErwhxAckiH2lyELilqbbk10VI/kTKb8y1yP+RmaRxHD1TzdUL5qAxlSQx8IVybnmKCgBW60FKDMsEy4m0AikVch8xkRkhThWFGHjckJFbPIw3m5iwbYK+PEGA43z6lPzUqhHB5Ww8Yeo9xwT26tDyzBhwF5rlHZ63CJ/DxMSQidY+E1ZEmJpN5UqUMxXmM54xAt2fakcUWRH6PY/w984Lc9xY/f667oef4Bgt82N9gjCVVoPERxNnJCgzJShmcnKB6KgTxmqzfI2E2WDqS/MVjoHBgzix04ZU8+gl+BG28HMf3eF3TKHCS4HJlTLZigyZIeuoM241bn+x8zq3WowAh43FtCEb3rmIAG0ur70nzf8=
 install:

--- a/ci/main.py
+++ b/ci/main.py
@@ -97,7 +97,7 @@ def is_not_uploaded(name, version, build_number, channel):
                      channel, name)
     log.info('Checking: {0}'.format(check_cmd))
     out = check_output(check_cmd, shell=True)
-    res = json.loads(out)
+    res = json.loads(out.decode('utf-8'))
 
     if name not in res:
         return True

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -10,7 +10,7 @@ case "${TRAVIS_OS_NAME}" in
 esac
 
 MINICONDA_URL="http://repo.continuum.io/miniconda"
-MINICONDA_FILE="Miniconda-latest-${os}-x86_64.sh"
+MINICONDA_FILE="Miniconda3-latest-${os}-x86_64.sh"
 wget "${MINICONDA_URL}/${MINICONDA_FILE}"
 bash $MINICONDA_FILE -b -p $HOME/miniconda
 


### PR DESCRIPTION
If we're moving to py3, it makes sense to start with minimal repos that are only used by devs.
