### PR TITLE
ENH: ssu-align

### DIFF
--- a/recipes/SSU-ALIGN/build.sh
+++ b/recipes/SSU-ALIGN/build.sh
@@ -1,5 +1,6 @@
 ./configure --prefix=$PREFIX
 make
+export SSUALIGNDIR=`pwd`
 make check
 make install
 echo export SSUALIGNDIR=$PREFIX/share/ssu-align-0.1 >> $PREFIX/.bash_profile

--- a/recipes/SSU-ALIGN/build.sh
+++ b/recipes/SSU-ALIGN/build.sh
@@ -1,5 +1,5 @@
 ./configure --prefix=$PREFIX
-make -j4
+make
 make check
 make install
-
+echo export SSUALIGNDIR=$PREFIX/share/ssu-align-0.1 >> $PREFIX/.bash_profile

--- a/recipes/SSU-ALIGN/build.sh
+++ b/recipes/SSU-ALIGN/build.sh
@@ -1,0 +1,5 @@
+./configure --prefix=$PREFIX
+make -j4
+make check
+make install
+

--- a/recipes/SSU-ALIGN/meta.yaml
+++ b/recipes/SSU-ALIGN/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: "0.1"
 
 source:
-  fn: ssu-align-0.1.tar.gz
-  url: ftp://selab.janelia.org/pub/software/ssu-align/ssu-align-0.1.tar.gz
+  fn: ssu-align-0.1.1.tar.gz
+  url: http://eddylab.org/software/ssu-align/ssu-align-0.1.1.tar.gz
  
 test:
   commands:

--- a/recipes/SSU-ALIGN/meta.yaml
+++ b/recipes/SSU-ALIGN/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: SSU-ALIGN
+  name: ssualign
   version: "0.1"
 
 source:
@@ -8,7 +8,7 @@ source:
  
 test:
   commands:
-    - # need to set SSUALIGNDIR
+    - source $PREFIX/.bash_profile
     - ssu-align -h
  
 about:

--- a/recipes/SSU-ALIGN/meta.yaml
+++ b/recipes/SSU-ALIGN/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  name: SSU-ALIGN
+  version: "0.1"
+
+source:
+  fn: ssu-align-0.1.tar.gz
+  url: ftp://selab.janelia.org/pub/software/ssu-align/ssu-align-0.1.tar.gz
+ 
+test:
+  commands:
+    - # need to set SSUALIGNDIR
+    - ssu-align -h
+ 
+about:
+  summary: SSU-ALIGN is a software package for identifying, aligning, masking and visualizing archaeal 16S, bacterial 16S and eukaryotic 18S small subunit ribosomal RNA (SSU rRNA) sequences. 
+  home: http://selab.janelia.org/software/ssu-align/
+  license: GPLv3
+  license_file: LICENSE


### PR DESCRIPTION
Need to set `$SSUALIGNDIR` in `build.sh`, so I do not expect this to pass yet. `make check` does not pass out of the box on my laptop due to a missing perl dependency (details below).

``` bash
$ make check
...snip...
Running Easel test suite...

Can't locate getopts.pl in @INC (@INC contains: /Library/Perl/5.18/darwin-thread-multi-2level /Library/Perl/5.18 /Network/Library/Perl/5.18/darwin-thread-multi-2level /Network/Library/Perl/5.18 /Library/Perl/Updates/5.18.2 /System/Library/Perl/5.18/darwin-thread-multi-2level /System/Library/Perl/5.18 /System/Library/Perl/Extras/5.18/darwin-thread-multi-2level /System/Library/Perl/Extras/5.18 .) at ./../devkit/sqc line 208.
make[2]: *** [run_sqc] Error 2
make[1]: *** [check] Error 2
make: *** [check] Error 2
```
