### PR TITLE
BLD: Updating conda build for gneiss

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ env:
     # CONDA_PY and CONDA_NPY are the env variable of python version
     # and numpy version used by "conda build"
     # to build the packages.
-    - CONDA_PY=35  CONDA_NPY=110
-    - CONDA_PY=36  CONDA_NPY=111
+    - CONDA_PY=35
+    - CONDA_PY=36
   global:
     - secure: gKgj4jR2N8WbVBnJCI52zMR21/nd2hWUb05DatiWNJ8pZ+CC6CPD7N/2t8k+y5V25NufI5ZpEBEnGbmV1AxS6ISjPHRejoQgDYTw/PjY4NEIssFVbULIB84FD9SY7/oqkr5L+jrEyDeV52d2LfSAHjwWlL4XYZ7OFdH7HW/5yUj1z4jasfFhv41x8tVknXWAeS1AEdAfwnb4lEeKvlP6jxdfqkQv9PeobM+THV7gGtUo9rA+plZuhQDzXhywRKajEbYbA7/eHzQa5kMYtf8EQl/orDOPCSMEjh9ifCsf0bcFuQkqtOKhgPGVihNdw9PErwhxAckiH2lyELilqbbk10VI/kTKb8y1yP+RmaRxHD1TzdUL5qAxlSQx8IVybnmKCgBW60FKDMsEy4m0AikVch8xkRkhThWFGHjckJFbPIw3m5iwbYK+PEGA43z6lPzUqhHB5Ww8Yeo9xwT26tDyzBhwF5rlHZ63CJ/DxMSQidY+E1ZEmJpN5UqUMxXmM54xAt2fakcUWRH6PY/w984Lc9xY/f667oef4Bgt82N9gjCVVoPERxNnJCgzJShmcnKB6KgTxmqzfI2E2WDqS/MVjoHBgzix04ZU8+gl+BG28HMf3eF3TKHCS4HJlTLZigyZIeuoM241bn+x8zq3WowAh43FtCEb3rmIAG0ur70nzf8=
 install:

--- a/recipes/gneiss/meta.yaml
+++ b/recipes/gneiss/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: gneiss
-  version: 0.4.0
+  version: 0.4.1
 
 source:
   git_url: https://github.com/biocore/gneiss.git
-  git_rev: v0.4.0
+  git_rev: v0.4.1
 
 build:
   number: 6
@@ -22,13 +22,6 @@ requirements:
     - seaborn
     - h5py
     - statsmodels >=0.8.0
-    - biom-format
-    - qiime2 ==2017.6.0
-    - q2cli ==2017.6.0
-    - q2-types ==2017.6.0
-    - q2-feature-table ==2017.6.0
-    - q2-composition ==2017.6.0
-    - q2-metadata ==2017.6.0
   run:
     - setuptools
     - python 3.5*
@@ -40,20 +33,11 @@ requirements:
     - bokeh
     - seaborn
     - h5py
-    - statsmodels >=0.8.0
-    - biom-format
-    - qiime2 ==2017.6.0
-    - q2cli ==2017.6.0
-    - q2-types ==2017.6.0
-    - q2-feature-table ==2017.6.0
-    - q2-composition ==2017.6.0
-    - q2-metadata ==2017.6.0
 
 test:
   # Python imports
   imports:
     - gneiss
-    - qiime2.plugins.gneiss
 
 about:
   home: https://github.com/biocore/gneiss

--- a/recipes/gneiss/meta.yaml
+++ b/recipes/gneiss/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - scikit-bio >=0.5.1
     - pandas
     - scipy
-    - numpy >=1.10
+    - numpy
     - matplotlib
     - bokeh
     - seaborn
@@ -28,7 +28,7 @@ requirements:
     - scikit-bio >=0.5.1
     - pandas
     - scipy
-    - numpy >=1.10
+    - numpy
     - matplotlib
     - bokeh
     - seaborn

--- a/recipes/gneiss/meta.yaml
+++ b/recipes/gneiss/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: gneiss
-  version: 0.4.1
+  version: 0.4.2
 
 source:
   git_url: https://github.com/biocore/gneiss.git
-  git_rev: v0.4.1
+  git_rev: v0.4.2
 
 build:
   number: 6

--- a/recipes/gneiss/meta.yaml
+++ b/recipes/gneiss/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - scikit-bio >=0.5.1
     - pandas
     - scipy
-    - numpy >=1.11
+    - numpy >=1.10
     - matplotlib
     - bokeh
     - seaborn
@@ -28,7 +28,7 @@ requirements:
     - scikit-bio >=0.5.1
     - pandas
     - scipy
-    - numpy >=1.11
+    - numpy >=1.10
     - matplotlib
     - bokeh
     - seaborn

--- a/recipes/gneiss/meta.yaml
+++ b/recipes/gneiss/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - numpy
     - matplotlib
     - bokeh
+    - biom-format
     - seaborn
     - h5py
     - statsmodels >=0.8.0
@@ -31,6 +32,7 @@ requirements:
     - numpy
     - matplotlib
     - bokeh
+    - biom-format
     - seaborn
     - h5py
 


### PR DESCRIPTION
We are pushing out another minor release of gneiss to handle the decoupling of qiime2 and gneiss.

As soon as this PR is pushed in, we can cut the release.

https://github.com/biocore/gneiss/pull/221