### PR TITLE
BLD: Updating conda build with deblur

### DIFF
--- a/recipes/deblur/meta.yaml
+++ b/recipes/deblur/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: deblur
-  version: "1.0.2"
+  version: "1.0.4"
 
 source:
   git_url: https://github.com/biocore/deblur.git
-  git_rev: 1.0.2
+  git_rev: 1.0.4
 
 build:
   number: 0


### PR DESCRIPTION
Updates deblur to version 1.0.4 to resolve vsearch masking issue