### PR TITLE
py 3.5* back in to solve conflicts in OSx

### DIFF
--- a/recipes/fragment-insertion/meta.yaml
+++ b/recipes/fragment-insertion/meta.yaml
@@ -41,11 +41,11 @@ build:
 
 requirements:
   build:
-    - python
+    - python 3.5*
     - setuptools
     - java-jdk
   run:
-    - python
+    - python 3.5*
     - setuptools
     - java-jdk
 


### PR DESCRIPTION
In the context of installing Qiita plugins, @josenavas suggested to remove the 3.5* restriction for the python dependency. That worked well for qiita. However, it causes dependency conflicts for OSx installing the q2-fragment-insertion plugin, which uses this package.
Therefore, I decided to add the restriction back in for a smooth installation of the q2 community plugin.