### PR TITLE
MAINT: Update mafft version in deblur recipe

### DIFF
--- a/recipes/deblur/meta.yaml
+++ b/recipes/deblur/meta.yaml
@@ -7,7 +7,7 @@ source:
   git_rev: 1.0.4
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -28,7 +28,7 @@ requirements:
     - setuptools
     - scikit-bio >=0.5.0
     - vsearch ==2.0.3
-    - mafft ==7.221
+    - mafft ==7.310
     - sortmerna ==2.0
     - biom-format
     - h5py


### PR DESCRIPTION
This version bump corresponds to the bump introduced here:
https://github.com/biocore/deblur/commit/08ed01809382ca5731cce9acb63fb9bb89fe42bb